### PR TITLE
This is a fix to remove the assumption that BambooHR will return the …

### DIFF
--- a/R/get_employee_data.R
+++ b/R/get_employee_data.R
@@ -28,6 +28,7 @@
 #' @export
 get_employee_data <- function(ids = NULL, fields=c("firstName","lastName","jobTitle","terminationDate","hireDate","location"), user = NULL, password = NULL, verbose = FALSE)
 {
+  ##get the meta data for the requested fields
   bamboo_meta_field_list <- get_bamboo_meta_fields(user = paste0(user), password = paste0(password), verbose = verbose)
 
   fields_meta_data <-
@@ -38,20 +39,31 @@ get_employee_data <- function(ids = NULL, fields=c("firstName","lastName","jobTi
   raw_data <-
     ids %>%
     purrr::pmap(~ {
-      httr::GET(paste("https://api.bamboohr.com/api/gateway.php/propellerpdx/v1/employees/",..1,"?fields=",paste(fields_meta_data$alias %>% as.list(),collapse = ","),sep=""),
-                httr::authenticate(user=paste0(user), password=paste0(password)),
-                config=config(verbose=verbose),
-                httr::add_headers("Accept" = "application/json")) %>%
+      ## Make the request to BambooHR for the fields requested for this specific id
+      data_returned <-
+        httr::GET(paste("https://api.bamboohr.com/api/gateway.php/propellerpdx/v1/employees/",..1,"?fields=",paste(fields_meta_data$alias %>% as.list(),collapse = ","),sep=""),
+                  httr::authenticate(user=paste0(user), password=paste0(password)),
+                  config=httr::config(verbose=verbose),
+                  httr::add_headers("Accept" = "application/json")) %>%
         httr::content(., as="text", encoding = "UTF-8") %>%
-        jsonlite::fromJSON() %>%
-        purrr::modify_at(dplyr::vars(as.character(fields_meta_data$alias)),~ ifelse(is.null(.),NA,.))
+        jsonlite::fromJSON()
+
+      ## BambooHR sometimes doesn't return requested fields (not sure why, but we have a bug submitted)
+      fields_returned <-
+        fields_meta_data$alias[tibble::has_name(data_returned, fields_meta_data$alias)]
+
+      ## set null fields to NA
+      data_returned %>%
+        purrr::modify_at(dplyr::vars(as.character(fields_returned)),~ ifelse(is.null(.),NA,.))
     }) %>%
     dplyr::bind_rows()
 
+  ## Get the types from the meta data API for the requested fields
   fields_meta_data  <-
     bamboo_meta_field_list %>%
     dplyr::filter(alias %in% names(raw_data))
 
+  ## Coerce the data types and return the result
   raw_data %>%
     purrr::modify_at(dplyr::vars(as.character(fields_meta_data[fields_meta_data$coerce_type == "as.Date",]$alias)),~ ifelse(.=="0000-00-00",NA,.)) %>%
     dplyr::mutate_at(dplyr::vars(as.character(fields_meta_data[fields_meta_data$coerce_type == "as.Date",]$alias)), as.Date) %>%


### PR DESCRIPTION
…fields requested. Not sure why the API is not returning requested fields (bug submitted). This update explicitly filters the meta data information to only the fields returned (which can be different between each record).